### PR TITLE
Pause stream on disconnection

### DIFF
--- a/clients/xiao-esp32s3-sense/firmware/src/main.cpp
+++ b/clients/xiao-esp32s3-sense/firmware/src/main.cpp
@@ -152,6 +152,11 @@ void setup()
 
 void loop()
 {
+  if (!s_is_connected) {
+    delay(50); // Wait for a connection
+    return;
+  }
+  
   unsigned long t0 = millis();
 
   size_t bytes_recorded = 0;


### PR DESCRIPTION
I'm not sure if it matters, since it seems to work without it. But we don't use s_is_connected otherwise